### PR TITLE
1.0.6に不具合があったためバージョンを1.0.5にする

### DIFF
--- a/Assets/Aramaa/DakochiteGimmick/package.json
+++ b/Assets/Aramaa/DakochiteGimmick/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jp.aramaa.dakochite-gimmick",
-    "version": "1.0.6",
-    "url": "https://github.com/aramaa-vr/dakochite-gimmick/releases/download/1.0.6/jp.aramaa.dakochite-gimmick-1.0.6.zip?",
+    "version": "1.0.5",
+    "url": "https://github.com/aramaa-vr/dakochite-gimmick/releases/download/1.0.5/jp.aramaa.dakochite-gimmick-1.0.5.zip?",
     "displayName": "dakochite-gimmick - みんなでつかめるだこちてギミック",
     "description": "VRChatアバター向けの抱っこされることができるギミックです。",
     "unity": "2022.3",


### PR DESCRIPTION
この修正をすることで、1.0.6のアップデート通知がツール上に出なくなる