### PR TITLE
[1.1.0] アバターのルートの座標が (0,0,0)以外でも疑似ビューポイントをずれなくする

### DIFF
--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/ConstraintSetupService.cs
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/ConstraintSetupService.cs
@@ -237,6 +237,7 @@ namespace Aramaa.DakochiteGimmick.Editor
             Transform constraintParentTransform = eyeOffsetTransform.parent;
 
             // Headの座標がVector3.zeroの場合、座標が更新されていないためエラー
+            // ルートの座標が(0,0,0)ではないケースも存在するため、ConstraintUpdateFailedOrTimedOutの適切な判定のために差分確認はローカルの座標で確認を行う
             if (constraintParentTransform == null || constraintParentTransform.localPosition == Vector3.zero)
             {
                 EditorErrorDialog.DisplayDialog(GimmickError.ConstraintUpdateFailedOrTimedOut);

--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/ConstraintSetupService.cs
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/ConstraintSetupService.cs
@@ -47,13 +47,6 @@ namespace Aramaa.DakochiteGimmick.Editor
                 return;
             }
 
-            // 疑似ビューポイントがずれるため、アバターのルートの座標が (0,0,0) からわずかでも離れている場合にエラーとする
-            if (Vector3.Distance(gimmickData.AvatarRootObject.transform.position, Vector3.zero) > GimmickConstants.AVATAR_ROOT_POSITION_TOLERANCE)
-            {
-                EditorErrorDialog.DisplayDialog(GimmickError.AvatarRootPositionIsNotZero);
-                return;
-            }
-
             // Hipsボーンの取得
             gimmickData.HipsBone = AvatarUtility.GetAnimatorHipsBone(gimmickData.AvatarRootObject);
             if (gimmickData.HipsBone == null)
@@ -250,8 +243,13 @@ namespace Aramaa.DakochiteGimmick.Editor
                 return false;
             }
 
-            // ViewPositionはアバターローカル座標なので、Constraintの親のローカル座標に変換して設定
-            Vector3 viewPositionInConstraintParentLocal = constraintParentTransform.InverseTransformPoint(gimmickData.AvatarDescriptor.ViewPosition);
+            // 1. ViewPosition（アバターのローカル座標）をワールド座標に変換する
+            Vector3 viewPositionInWorld = gimmickData.AvatarDescriptor.transform.TransformPoint(gimmickData.AvatarDescriptor.ViewPosition);
+
+            // 2. ワールド座標に変換したViewPositionを、Constraintの親のローカル座標に変換する
+            Vector3 viewPositionInConstraintParentLocal = constraintParentTransform.InverseTransformPoint(viewPositionInWorld);
+
+            // 3. 変換したローカル座標を設定する
             eyeOffsetTransform.localPosition = viewPositionInConstraintParentLocal;
 
             // Headボーンの回転の逆をEyeOffsetのローカル回転に設定（Headの回転を打ち消すことで視線に合わせる）

--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/ConstraintSetupService.cs
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/ConstraintSetupService.cs
@@ -244,7 +244,8 @@ namespace Aramaa.DakochiteGimmick.Editor
             }
 
             // 1. ViewPosition（アバターのローカル座標）をワールド座標に変換する
-            Vector3 viewPositionInWorld = gimmickData.AvatarDescriptor.transform.TransformPoint(gimmickData.AvatarDescriptor.ViewPosition);
+            // ViewPositionそのものはスケールの値に依存しない作りのため別途加算にする
+            Vector3 viewPositionInWorld = gimmickData.AvatarDescriptor.transform.position + gimmickData.AvatarDescriptor.ViewPosition;
 
             // 2. ワールド座標に変換したViewPositionを、Constraintの親のローカル座標に変換する
             Vector3 viewPositionInConstraintParentLocal = constraintParentTransform.InverseTransformPoint(viewPositionInWorld);

--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/ConstraintSetupService.cs
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/ConstraintSetupService.cs
@@ -237,7 +237,7 @@ namespace Aramaa.DakochiteGimmick.Editor
             Transform constraintParentTransform = eyeOffsetTransform.parent;
 
             // Headの座標がVector3.zeroの場合、座標が更新されていないためエラー
-            if (constraintParentTransform == null || constraintParentTransform.position == Vector3.zero)
+            if (constraintParentTransform == null || constraintParentTransform.localPosition == Vector3.zero)
             {
                 EditorErrorDialog.DisplayDialog(GimmickError.ConstraintUpdateFailedOrTimedOut);
                 return false;

--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Textures/manual.png.meta
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Textures/manual.png.meta
@@ -5,7 +5,7 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 12
   mipmaps:
-    mipMapMode: 0
+    mipMapMode: 1
     enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0

--- a/Assets/Aramaa/DakochiteGimmick/Fontopo/Textures/DakochiteText.png.meta
+++ b/Assets/Aramaa/DakochiteGimmick/Fontopo/Textures/DakochiteText.png.meta
@@ -5,7 +5,7 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 12
   mipmaps:
-    mipMapMode: 0
+    mipMapMode: 1
     enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0


### PR DESCRIPTION
1. AvatarRootPositionIsNotZeroを行わなくて済むようにする
3. ConstraintUpdateFailedOrTimedOutの適切な判定のために差分確認はローカルの座標で確認を行う