### PR TITLE
Develop/1.1.3

### DIFF
--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Menus/HoldGimickMenuMain.asset
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Menus/HoldGimickMenuMain.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Parameters: {fileID: 0}
   controls:
-  - name: "\u3060\u3053\u3061\u3066\nver 1.1.2"
+  - name: "\u3060\u3053\u3061\u3066\nver 1.1.3"
     icon: {fileID: 2800000, guid: 670a2379dbed2e6418d831fa027db76c, type: 3}
     type: 103
     parameter:

--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/Aramaa.DakochiteGimmick.Editor.asmdef
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/Aramaa.DakochiteGimmick.Editor.asmdef
@@ -13,7 +13,21 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
+    "defineConstraints": [
+        "VALID_VRCSDK_BASE",
+        "VALID_VRCSDK3_AVATARS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.base",
+            "expression": "3.8.2",
+            "define": "VALID_VRCSDK_BASE"
+        },
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "3.8.2",
+            "define": "VALID_VRCSDK3_AVATARS"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/GimickConstants.cs
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/GimickConstants.cs
@@ -6,7 +6,7 @@ namespace Aramaa.DakochiteGimmick.Editor
     public static class GimmickConstants
     {
         // 説明書
-        public const string DOCUMENTATION_URL = "https://docs.google.com/document/d/141h1qxOo8ZeFPDXLFmx2fjn6jsYxf7dL6XJkSFxztec/edit?usp=sharing";
+        public const string DOCUMENTATION_URL = "https://aramaa-vr.github.io/dakochite-gimmick-pages/";
         public const string CHANGELOG_URL = "https://aramaa-vr.github.io/dakochite-gimmick/CHANGELOG.md";
 
         // ====================================================================================================

--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/PackageUpdater.cs
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/PackageUpdater.cs
@@ -17,7 +17,7 @@ namespace Aramaa.DakochiteGimmick.Editor
 
         // ローカルのインストール済みパッケージバージョン (コード上でハードコード)
         // ここに現在プロジェクトに導入されているギミックのバージョンを直接入力してください。
-        public const string LOCAL_INSTALLED_VERSION = "1.1.2"; // ここに実際のバージョンを記述します
+        public const string LOCAL_INSTALLED_VERSION = "1.1.3"; // ここに実際のバージョンを記述します
 
         /// <summary>
         /// JSONからバージョン情報をデシリアライズするためのクラス。

--- a/Assets/Aramaa/DakochiteGimmick/README.md
+++ b/Assets/Aramaa/DakochiteGimmick/README.md
@@ -11,6 +11,6 @@ VRChatアバター向けの抱っこされることができるギミックで�
 [Booth](https://aramaa.booth.pm/items/7016968)(1.0.0)
 
 ## 説明書
-ギミックの詳しい使い方については、以下の説明書をご覧ください。
+ギミックの導入や詳しい使い方については、以下の説明書をご覧ください。
 
-[説明書（Google ドキュメント）](https://docs.google.com/document/d/141h1qxOo8ZeFPDXLFmx2fjn6jsYxf7dL6XJkSFxztec/edit?usp=sharing)
+[説明書](https://aramaa-vr.github.io/dakochite-gimmick-pages/)

--- a/Assets/Aramaa/DakochiteGimmick/package.json
+++ b/Assets/Aramaa/DakochiteGimmick/package.json
@@ -17,9 +17,7 @@
         "Assets\\Aramaa\\HoldGimick": "68e9b3fe244621a4b9e799b1ff081200"
     },
     "vpmDependencies": {
-        "com.vrchat.avatars": ">=3.8.2",
-        "com.vrchat.base": ">=3.8.2",
-        "nadena.dev.modular-avatar": ">=1.12.5"
+        "nadena.dev.modular-avatar": "^1.12.5"
     },
     "type": "avatar",
     "keywords": [

--- a/Assets/Aramaa/DakochiteGimmick/package.json
+++ b/Assets/Aramaa/DakochiteGimmick/package.json
@@ -6,7 +6,7 @@
     "description": "VRChatアバター向けの抱っこされることができるギミックです。",
     "unity": "2022.3",
     "unityRelease": "22f1",
-    "documentationUrl": "https://docs.google.com/document/d/141h1qxOo8ZeFPDXLFmx2fjn6jsYxf7dL6XJkSFxztec/edit?usp=sharing",
+    "documentationUrl": "https://aramaa-vr.github.io/dakochite-gimmick-pages/",
     "changelogUrl": "https://github.com/aramaa-vr/dakochite-gimmick/blob/master/CHANGELOG.md",
     "licensesUrl": "https://github.com/aramaa-vr/dakochite-gimmick/blob/master/LICENSE",
     "license": "Custom",

--- a/Assets/Aramaa/DakochiteGimmick/package.json
+++ b/Assets/Aramaa/DakochiteGimmick/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jp.aramaa.dakochite-gimmick",
-    "version": "1.1.2",
-    "url": "https://github.com/aramaa-vr/dakochite-gimmick/releases/download/1.1.2/jp.aramaa.dakochite-gimmick-1.1.2.zip?",
+    "version": "1.1.3",
+    "url": "https://github.com/aramaa-vr/dakochite-gimmick/releases/download/1.1.3/jp.aramaa.dakochite-gimmick-1.1.3.zip?",
     "displayName": "dakochite-gimmick - みんなでつかめるだこちてギミック",
     "description": "VRChatアバター向けの抱っこされることができるギミックです。",
     "unity": "2022.3",


### PR DESCRIPTION
こっち見て色々整理する（vpm上では1.1.2の時点でcom.vrchat.avatars等の依存を切るようにしている）
https://github.com/aramaa-vr/vpm-repos/pull/34

Closeして色々考え直した方がいい

nadena.dev.modular-avatarを依存関係に入れなくても動作するようにし、
入っていない場合にエラーを出すようにする等作りを適切にする