### PR TITLE
Align editor asmdef with version-defined VRChat SDK checks

### DIFF
--- a/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/Aramaa.DakochiteGimmick.Editor.asmdef
+++ b/Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/Aramaa.DakochiteGimmick.Editor.asmdef
@@ -13,7 +13,21 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
+    "defineConstraints": [
+        "VALID_VRCSDK_BASE",
+        "VALID_VRCSDK3_AVATARS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.base",
+            "expression": "3.8.2",
+            "define": "VALID_VRCSDK_BASE"
+        },
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "3.8.2",
+            "define": "VALID_VRCSDK3_AVATARS"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
### Motivation
- Ensure the Editor assembly only compiles when the VRChat SDK packages are present and at a compatible version to avoid editor compile errors when the SDK is absent. 
- Match the style used in the provided `face-emo` asmdef reference by using `versionDefines` to derive conditional compilation symbols from package versions. 
- Preserve existing Modular Avatar references without forcing VRChat packages into `vpmDependencies` so the project remains optional for users without VRChat SDK installed.

### Description
- Updated `Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/Aramaa.DakochiteGimmick.Editor.asmdef` to set `defineConstraints` to `VALID_VRCSDK_BASE` and `VALID_VRCSDK3_AVATARS` instead of unconditional compilation. 
- Added `versionDefines` entries for `com.vrchat.base` and `com.vrchat.avatars` with `expression` set to `3.8.2` that define the above symbols. 
- Kept `references` as `nadena.dev.modular-avatar.core` and `nadena.dev.modular-avatar.core.editor` and did not add VRChat packages to `vpmDependencies`. 
- Left `overrideReferences`/`autoReferenced` behavior unchanged so precompiled/engine references are not forced.

### Testing
- Verified VRChat and Modular Avatar usages with `rg -n "using VRC\.|using nadena\.dev" Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/*.cs` and confirmed the editor scripts reference `VRC.SDK3.*`, `VRC.Dynamics`, and `nadena.dev.modular_avatar.core`. (succeeded)
- Parsed the updated asmdef with a Python JSON check of `Assets/Aramaa/DakochiteGimmick/Aramaa/Scripts/Editor/Aramaa.DakochiteGimmick.Editor.asmdef` to confirm `defineConstraints` and `versionDefines` are present and correct. (succeeded)
- Inspected `Assets/Aramaa/DakochiteGimmick/package.json` with a Python JSON check to confirm `vpmDependencies` remains `nadena.dev.modular-avatar` only. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986ced5793883249fba8de2510c8322)