### PR TITLE
Update documentationUrl in DakochiteGimmick package.json to GitHub Pages

### DIFF
--- a/Assets/Aramaa/DakochiteGimmick/package.json
+++ b/Assets/Aramaa/DakochiteGimmick/package.json
@@ -6,7 +6,7 @@
     "description": "VRChatアバター向けの抱っこされることができるギミックです。",
     "unity": "2022.3",
     "unityRelease": "22f1",
-    "documentationUrl": "https://docs.google.com/document/d/141h1qxOo8ZeFPDXLFmx2fjn6jsYxf7dL6XJkSFxztec/edit?usp=sharing",
+    "documentationUrl": "https://aramaa-vr.github.io/dakochite-gimmick-pages/",
     "changelogUrl": "https://github.com/aramaa-vr/dakochite-gimmick/blob/master/CHANGELOG.md",
     "licensesUrl": "https://github.com/aramaa-vr/dakochite-gimmick/blob/master/LICENSE",
     "license": "Custom",


### PR DESCRIPTION
### Motivation
- パッケージメタデータが旧 Google Docs の URL を参照していたため、リポジトリ内で使っている新しい GitHub Pages の説明書 URL に揃える目的で更新しました。

### Description
- `Assets/Aramaa/DakochiteGimmick/package.json` の `documentationUrl` を `https://aramaa-vr.github.io/dakochite-gimmick-pages/` に置き換えました。

### Testing
- `Assets/Aramaa/DakochiteGimmick/package.json` を `python -m json.tool` で検証し、JSON のパースが成功することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986d42ab3c88324b69876b60e7b7e1c)