### PR TITLE
Add .vscode and *.slnx to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vscode/
 
 # Gradle cache directory
 .gradle/
@@ -20,6 +21,7 @@ ExportedObj/
 *.csproj
 *.unityproj
 *.sln
+*.slnx
 *.suo
 *.tmp
 *.user


### PR DESCRIPTION
### Motivation
- Prevent committing editor-specific VS Code settings and newer Visual Studio solution variants by ignoring ` .vscode` and `*.slnx` in the repository.

### Description
- Updated `.gitignore` to add the ` .vscode` directory and the `*.slnx` file pattern.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4f7eb058c8324ba8e6aa2d4be4330)